### PR TITLE
Skip check when remote_oid is zero

### DIFF
--- a/pre-push.sample
+++ b/pre-push.sample
@@ -5,7 +5,7 @@ zero="$(git hash-object --stdin </dev/null | tr '0-9a-f' '0')"
 # shellcheck disable=SC2034
 while read -r local_ref local_oid remote_ref remote_oid
 do
-    if [ "$local_oid" = "$zero" ]; then
+    if [ "$local_oid" = "$zero" ] || [ "$remote_oid" = "$zero" ]; then
         continue
     fi
 


### PR DESCRIPTION
Without this change, a command like
```
git push origin HEAD:refs/heads/new-branch
```
will produce this error:
```
fatal: bad object 0000000000000000000000000000000000000000
```